### PR TITLE
Fix isJsDom navigator check

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -19,9 +19,14 @@ const isNode = typeof process !== 'undefined'
  * @see https://github.com/jsdom/jsdom/issues/1537
  */
 /* eslint-disable no-undef */
-const isJsDom = () => (typeof window !== 'undefined' && window.name === 'nodejs')
-  || navigator.userAgent.includes('Node.js')
-  || navigator.userAgent.includes('jsdom');
+const isJsDom = () => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  return (typeof window !== 'undefined' && window.name === 'nodejs')
+    || navigator.userAgent.includes('Node.js')
+    || navigator.userAgent.includes('jsdom');
+};
 
 module.exports = exports = {
   isBrowser, isWebWorker, isNode, isJsDom


### PR DESCRIPTION
## Summary
- avoid ReferenceError when navigator is undefined

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684beee5e8b08323b2b0880455062229